### PR TITLE
INFRA-8066 Remove delayer lambda outputs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,9 +28,9 @@ terraform-fmt-check:
 	docker run -v ${PWD}:/src -w /src/terraform hashicorp/terraform:$(TERRAFORM_VERSION) fmt -recursive -check
 
 terraform-validate:
-	cd terraform && tfenv install $(TERRAFORM_VERSION)
-	cd terraform && terraform init -backend=false
-	cd terraform && terraform validate
+	@echo "Not implemented because we can't clone remote modules"
+# docker run --rm -v ${PWD}:/src -w /src/terraform hashicorp/terraform:$(TERRAFORM_VERSION) init -backend=false
+# docker run --rm -v ${PWD}:/src -w /src/terraform hashicorp/terraform:$(TERRAFORM_VERSION) validate
 
 terraform-security-check: clean
 	docker run --rm -u 0 -v ${PWD}:/src tfsec/tfsec:latest /src/terraform

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ terraform-fmt-check:
 	docker run -v ${PWD}:/src -w /src/terraform hashicorp/terraform:$(TERRAFORM_VERSION) fmt -recursive -check
 
 terraform-validate:
-	cd terraform && tfswitch
+	cd terraform && tfenv install $(TERRAFORM_VERSION)
 	cd terraform && terraform init -backend=false
 	cd terraform && terraform validate
 

--- a/Makefile
+++ b/Makefile
@@ -28,9 +28,9 @@ terraform-fmt-check:
 	docker run -v ${PWD}:/src -w /src/terraform hashicorp/terraform:$(TERRAFORM_VERSION) fmt -recursive -check
 
 terraform-validate:
-	@echo "Not implemented because we can't clone remote modules"
-# docker run --rm -v ${PWD}:/src -w /src/terraform hashicorp/terraform:$(TERRAFORM_VERSION) init -backend=false
-# docker run --rm -v ${PWD}:/src -w /src/terraform hashicorp/terraform:$(TERRAFORM_VERSION) validate
+	cd terraform && tfswitch
+	cd terraform && terraform init -backend=false
+	cd terraform && terraform validate
 
 terraform-security-check: clean
 	docker run --rm -u 0 -v ${PWD}:/src tfsec/tfsec:latest /src/terraform

--- a/README.md
+++ b/README.md
@@ -127,5 +127,4 @@ autorecycle_dry_run: "true" or "false"
 The strategy key above defines the method for recycling and is used by the step function to choose the path to take.
 
 * out-in - this will double the size of an autoscaling group to scale up and halve the size of the autoscaling group to scale down. This is the standard default method.
-* out-in-timed - the same as out-in but with an exclusion window, used by payments-sftp
 * in-out - one at a time instance scaling in and then out. Used where we have ENI e.g. rate_hods_proxy

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -86,27 +86,6 @@ output "autorecycle_mongo_lambda_security_group" {
   value = var.autorecycle_mongo_lambda_vpc_id != null ? module.autorecycle_mongo_lambda[0].security_group_id : null
 }
 
-# autorecycle_delayer_lambda
-output "autorecycle_delayer_lambda_alias_name" {
-  value = module.autorecycle_delayer_lambda.lambda_alias_name
-}
-
-output "autorecycle_delayer_lambda_arn" {
-  value = module.autorecycle_delayer_lambda.lambda_alias_arn
-}
-
-output "autorecycle_delayer_lambda_name" {
-  value = module.autorecycle_delayer_lambda.lambda_name
-}
-
-output "autorecycle_delayer_lambda_role_arn" {
-  value = module.autorecycle_delayer_lambda.iam_role_arn
-}
-
-output "autorecycle_delayer_lambda_role" {
-  value = module.autorecycle_delayer_lambda.iam_role_id
-}
-
 # autorecycle_lambda
 output "autorecycle_lambda_alias_name" {
   value = module.autorecycle_lambda.lambda_alias_name

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = "~> 1.2"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">=4.67.0"
+    }
+  }
+}

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.2"
+  required_version = ">=1.3.0"
 
   required_providers {
     aws = {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -79,7 +79,3 @@ variable "start_instance_refresh_lambda_name" {
   type        = string
   default     = ""
 }
-
-variable "payments_delayer_var" {
-  default = "09:45:00, 11:15:00, 11:30:00"
-}


### PR DESCRIPTION
They are not used anymore.

The terraform-validate step doesn't actually validate terraform, or this would have been caught in the last PR. I suspect none of the lambda repos do. I have validated it manually.