### PR TITLE
BAU Don't fail autorecycling for scaled down components

### DIFF
--- a/src/monitor_autorecycle/main.py
+++ b/src/monitor_autorecycle/main.py
@@ -12,7 +12,10 @@ config = Config(retries={"max_attempts": 60, "mode": "standard"})
 logger = logging.getLogger("monitor_autorecycle")
 logger.setLevel(logging.INFO)
 
-class ScaledDownASGException(Exception): pass
+
+class ScaledDownASGException(Exception):
+    pass
+
 
 def lambda_handler(event: Any, context: Any) -> Any:
     aws_lambda_logging.setup(

--- a/tests/test_data/monitor_autorecycle/describe_asg_lc.py
+++ b/tests/test_data/monitor_autorecycle/describe_asg_lc.py
@@ -6,6 +6,7 @@ def launch_configuration_asgs():
         "AutoScalingGroups": [
             {
                 "AutoScalingGroupName": "public_routing_proxy_healthy-asg-123",
+                "MaxSize": 2,
                 "Instances": [
                     {
                         "InstanceId": "i-1",
@@ -27,6 +28,7 @@ def launch_configuration_asgs():
             },
             {
                 "AutoScalingGroupName": "public_routing_proxy_unhealthy-asg-123",
+                "MaxSize": 2,
                 "Instances": [
                     {
                         "InstanceId": "i-3",
@@ -48,6 +50,7 @@ def launch_configuration_asgs():
             },
             {
                 "AutoScalingGroupName": "public_routing_proxy_terminating-asg-123",
+                "MaxSize": 2,
                 "Instances": [
                     {
                         "InstanceId": "i-5",
@@ -69,6 +72,7 @@ def launch_configuration_asgs():
             },
             {
                 "AutoScalingGroupName": "public_routing_proxy_no_lc-asg-123",
+                "MaxSize": 2,
                 "Instances": [
                     {
                         "InstanceId": "i-7",
@@ -89,6 +93,7 @@ def launch_configuration_asgs():
             },
             {
                 "AutoScalingGroupName": "public_routing_proxy-asg-123",
+                "MaxSize": 1,
                 "Instances": [
                     {
                         "InstanceId": "i-9",

--- a/tests/test_data/monitor_autorecycle/describe_asg_lt.py
+++ b/tests/test_data/monitor_autorecycle/describe_asg_lt.py
@@ -7,6 +7,7 @@ def launch_template_asgs():
             {
                 "AutoScalingGroupName": "public-mdtp-uptodate-asg-123",
                 "LaunchTemplate": {"Version": "10"},
+                "MaxSize": 2,
                 "Instances": [
                     {
                         "InstanceId": "i-9",
@@ -29,6 +30,7 @@ def launch_template_asgs():
             {
                 "AutoScalingGroupName": "public-mdtp-not-uptodate-asg-123",
                 "LaunchTemplate": {"Version": "10"},
+                "MaxSize": 2,
                 "Instances": [
                     {
                         "InstanceId": "i-9",
@@ -51,6 +53,7 @@ def launch_template_asgs():
             {
                 "AutoScalingGroupName": "public-mdtp-unhealthy-asg-123",
                 "LaunchTemplate": {"Version": "10"},
+                "MaxSize": 2,
                 "Instances": [
                     {
                         "InstanceId": "i-11",
@@ -73,6 +76,7 @@ def launch_template_asgs():
             {
                 "AutoScalingGroupName": "public-mdtp-terminating-asg-123",
                 "LaunchTemplate": {"Version": "10"},
+                "MaxSize": 2,
                 "Instances": [
                     {
                         "InstanceId": "i-13",
@@ -95,6 +99,7 @@ def launch_template_asgs():
             {
                 "AutoScalingGroupName": "public-mdtp-NotInService-asg-123",
                 "LaunchTemplate": {"Version": "10"},
+                "MaxSize": 2,
                 "Instances": [
                     {
                         "InstanceId": "i-11",

--- a/tests/unit/monitor_autorecycle/test_monitor_autorecycling.py
+++ b/tests/unit/monitor_autorecycle/test_monitor_autorecycling.py
@@ -3,6 +3,7 @@ from datetime import datetime, timedelta
 from unittest.mock import MagicMock, call, patch
 
 from src.monitor_autorecycle.main import (
+    ScaledDownASGException,
     _compare_start_times,
     _describe_asg,
     _describe_scaling_activities,
@@ -12,7 +13,6 @@ from src.monitor_autorecycle.main import (
     check_instances,
     config,
     lambda_handler,
-    ScaledDownASGException
 )
 from tests.test_data.monitor_autorecycle.describe_asg_lc import launch_configuration_asgs
 from tests.test_data.monitor_autorecycle.describe_asg_lt import launch_template_asgs
@@ -621,6 +621,7 @@ class DescribeAsg(unittest.TestCase):
 
         with self.assertRaises(ScaledDownASGException):
             _describe_asg(component)
+
 
 @patch("boto3.client")
 class DescribeScalingActivities(unittest.TestCase):


### PR DESCRIPTION
Just succeed without doing anything. The notification message will say no recycling happened, because there were no instances.
