### PR TITLE
INFRA-8144: Disable error alarms for the lambdas

### DIFF
--- a/terraform/autorecycle_lambda.tf
+++ b/terraform/autorecycle_lambda.tf
@@ -6,6 +6,7 @@ module "autorecycle_lambda" {
   environment_variables = {
     environment = var.environment
   }
+  enable_error_alarm                      = false
   error_alarm_runbook                     = local.runbook_url
   function_name                           = "autorecycle"
   image_command                           = ["autorecycle.autorecycle_lambda.lambda_handler"]

--- a/terraform/autorecycle_mongo_lambda.tf
+++ b/terraform/autorecycle_mongo_lambda.tf
@@ -9,6 +9,7 @@ module "autorecycle_mongo_lambda" {
     VAULT_URL   = "https://vault.${var.environment}.mdtp:8200"
     CA_CERT     = "src/mongo_recycler/mdtp.pem"
   }
+  enable_error_alarm                      = false
   error_alarm_runbook                     = local.runbook_url
   function_name                           = "aws-autorecycle-mongo-lambda"
   image_command                           = ["mongo_recycler.process.step.lambda_handler"]

--- a/terraform/invoke_stepfunctions_lambda.tf
+++ b/terraform/invoke_stepfunctions_lambda.tf
@@ -8,6 +8,7 @@ module "invoke_stepfunctions_lambda" {
     "ACCOUNT_ID"    = data.aws_caller_identity.current.account_id
     "SLACK_CHANNEL" = var.slack_channel
   }
+  enable_error_alarm                      = false
   error_alarm_runbook                     = local.runbook_url
   function_name                           = "autorecycle-invoke-stepfunctions"
   image_command                           = ["autorecycle_invoke_stepfunctions.handler.lambda_handler"]

--- a/terraform/monitor_autorecycle_lambda.tf
+++ b/terraform/monitor_autorecycle_lambda.tf
@@ -4,6 +4,7 @@ module "monitor_autorecycle_lambda" {
   account_engineering_boundary            = var.account_engineering_boundary
   environment                             = var.environment
   environment_variables                   = {}
+  enable_error_alarm                      = false
   error_alarm_runbook                     = local.runbook_url
   function_name                           = "monitor-autorecycle"
   image_command                           = ["monitor_autorecycle.main.lambda_handler"]

--- a/terraform/scale_asg_lambda.tf
+++ b/terraform/scale_asg_lambda.tf
@@ -6,6 +6,7 @@ module "autorecycle_scale_asg_lambda" {
   environment_variables = {
     ENVIRONMENT = var.environment
   }
+  enable_error_alarm                      = false
   error_alarm_runbook                     = local.runbook_url
   function_name                           = "autorecycle-scale-asg"
   image_command                           = ["autorecycle_scale_asg.handler.lambda_handler"]

--- a/terraform/state_machine.tf
+++ b/terraform/state_machine.tf
@@ -621,7 +621,7 @@ resource "aws_sfn_state_machine" "auto_recycle" {
         "component.$": "$.component",
         "status": "fail",
         "message_content": {
-          "text": "Failed to recycle a component: https://confluence.tools.tax.service.gov.uk/display/WEBOPS/Recycling+Instances+in+Auto+Scaling+Groups",
+          "text": "Failed to recycle a component: ${local.runbook_url}",
           "color": "danger",
           "fields": [
             {


### PR DESCRIPTION
The step function catches any lambda errors and sends a message to Slack, we don't need to create the alarms.