### PR TITLE
BAU - Updating poetry dependency on packaging module

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ types-pytz = "^2023.3.0.0"
 types-requests = "<2.31.0.7"
 types-pyopenssl = "^23.2.0.2"
 aws-lambda-context = "^1.1.0"
+packaging = "^24.0"
 
 [tool.black]
 line-length = 88


### PR DESCRIPTION
This PR will update poetry dependency on packaging module to fix the below error seen in this [failed jenkins job](https://jenkins.tools.management.tax.service.gov.uk/job/lambda/job/aws-autorecycle/job/main/69/console). 

```05:26:08  22.85 No module named 'packaging.metadata' ```