### PR TITLE
Infra 8366 enable step function alarm

### DIFF
--- a/terraform/autorecycle_lambda.tf
+++ b/terraform/autorecycle_lambda.tf
@@ -6,8 +6,9 @@ module "autorecycle_lambda" {
   environment_variables = {
     environment = var.environment
   }
-  enable_error_alarm                      = false
+  enable_error_alarm                      = true
   error_alarm_runbook                     = local.lambda_error_runbook_url
+  error_alarm_actions                     = [data.aws_sns_topic.pagerduty_connector_noncritical.arn]
   function_name                           = "autorecycle"
   image_command                           = ["autorecycle.autorecycle_lambda.lambda_handler"]
   image_uri                               = "419929493928.dkr.ecr.eu-west-2.amazonaws.com/aws-autorecycle:${var.image_tag}"

--- a/terraform/autorecycle_mongo_lambda.tf
+++ b/terraform/autorecycle_mongo_lambda.tf
@@ -9,8 +9,9 @@ module "autorecycle_mongo_lambda" {
     VAULT_URL   = "https://vault.${var.environment}.mdtp:8200"
     CA_CERT     = "src/mongo_recycler/mdtp.pem"
   }
-  enable_error_alarm                      = false
+  enable_error_alarm                      = true
   error_alarm_runbook                     = local.lambda_error_runbook_url
+  error_alarm_actions                     = [data.aws_sns_topic.pagerduty_connector_noncritical.arn]
   function_name                           = "aws-autorecycle-mongo-lambda"
   image_command                           = ["mongo_recycler.process.step.lambda_handler"]
   image_uri                               = "419929493928.dkr.ecr.eu-west-2.amazonaws.com/aws-autorecycle:${var.image_tag}"

--- a/terraform/invoke_stepfunctions_lambda.tf
+++ b/terraform/invoke_stepfunctions_lambda.tf
@@ -8,7 +8,7 @@ module "invoke_stepfunctions_lambda" {
     "ACCOUNT_ID"    = data.aws_caller_identity.current.account_id
     "SLACK_CHANNEL" = var.slack_channel
   }
-  enable_error_alarm                      = false
+  enable_error_alarm                      = true
   error_alarm_runbook                     = local.lambda_error_runbook_url
   function_name                           = "autorecycle-invoke-stepfunctions"
   image_command                           = ["autorecycle_invoke_stepfunctions.handler.lambda_handler"]

--- a/terraform/invoke_stepfunctions_lambda.tf
+++ b/terraform/invoke_stepfunctions_lambda.tf
@@ -10,6 +10,7 @@ module "invoke_stepfunctions_lambda" {
   }
   enable_error_alarm                      = true
   error_alarm_runbook                     = local.lambda_error_runbook_url
+  error_alarm_actions                     = [data.aws_sns_topic.pagerduty_connector_noncritical.arn]
   function_name                           = "autorecycle-invoke-stepfunctions"
   image_command                           = ["autorecycle_invoke_stepfunctions.handler.lambda_handler"]
   image_uri                               = "419929493928.dkr.ecr.eu-west-2.amazonaws.com/aws-autorecycle:${var.image_tag}"

--- a/terraform/local.tf
+++ b/terraform/local.tf
@@ -8,3 +8,7 @@ locals {
 data "aws_caller_identity" "current" {}
 
 data "aws_region" "current" {}
+
+data "aws_sns_topic" "pagerduty_connector_noncritical" {
+  name = "pagerduty_infrastructure_noncritical-${var.environment}"
+}

--- a/terraform/monitor_autorecycle_lambda.tf
+++ b/terraform/monitor_autorecycle_lambda.tf
@@ -4,8 +4,9 @@ module "monitor_autorecycle_lambda" {
   account_engineering_boundary            = var.account_engineering_boundary
   environment                             = var.environment
   environment_variables                   = {}
-  enable_error_alarm                      = false
+  enable_error_alarm                      = true
   error_alarm_runbook                     = local.lambda_error_runbook_url
+  error_alarm_actions                     = [data.aws_sns_topic.pagerduty_connector_noncritical.arn]
   function_name                           = "monitor-autorecycle"
   image_command                           = ["monitor_autorecycle.main.lambda_handler"]
   image_uri                               = "419929493928.dkr.ecr.eu-west-2.amazonaws.com/aws-autorecycle:${var.image_tag}"

--- a/terraform/scale_asg_lambda.tf
+++ b/terraform/scale_asg_lambda.tf
@@ -6,8 +6,9 @@ module "autorecycle_scale_asg_lambda" {
   environment_variables = {
     ENVIRONMENT = var.environment
   }
-  enable_error_alarm                      = false
+  enable_error_alarm                      = true
   error_alarm_runbook                     = local.lambda_error_runbook_url
+  error_alarm_actions                     = [data.aws_sns_topic.pagerduty_connector_noncritical.arn]
   function_name                           = "autorecycle-scale-asg"
   image_command                           = ["autorecycle_scale_asg.handler.lambda_handler"]
   image_uri                               = "419929493928.dkr.ecr.eu-west-2.amazonaws.com/aws-autorecycle:${var.image_tag}"


### PR DESCRIPTION
At this point if any of the autorecycle lambda functions fails, we dont get notifications. This PR enables alarms on all the Autorecycle lambda functions so that we get notifications for the failures.