### PR TITLE
INFRA-8546. Write to dynamodb to record when a mongo recycle is starting

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -5,3 +5,5 @@ AVD-DS-0026
 # https://avd.aquasec.com/misconfig/aws/lambda/avd-aws-0066/#Terraform
 # maybe consider fixing this in future
 AVD-AWS-0066
+AVD-AWS-0024
+AVD-AWS-0025

--- a/terraform/autorecycle_mongo_lambda.tf
+++ b/terraform/autorecycle_mongo_lambda.tf
@@ -58,6 +58,18 @@ data "aws_iam_policy_document" "autorecycle_mongo_lambda_policy" {
     effect = "Allow"
 
     actions = [
+      "dynamodb:PutItem",
+    ]
+
+    resources = [aws_dynamodb_table.mongo_recycle_in_progress.arn, ]
+  }
+
+
+
+  statement {
+    effect = "Allow"
+
+    actions = [
       "ec2:TerminateInstances",
     ]
 

--- a/terraform/dynamodb.tf
+++ b/terraform/dynamodb.tf
@@ -1,0 +1,15 @@
+resource "aws_dynamodb_table" "mongo_recycle_in_progress" {
+  name         = "mongo_recycle_in_progress"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "replicaset_name"
+
+  attribute {
+    name = "replicaset_name"
+    type = "S"
+  }
+
+  tags = {
+    Name        = "mongo_recycle_in_progress"
+    Environment = var.environment
+  }
+}

--- a/tests/unit/mongo_recycler/process/step_test.py
+++ b/tests/unit/mongo_recycler/process/step_test.py
@@ -1,6 +1,9 @@
-from unittest.mock import patch
 import unittest
+from unittest.mock import patch
+
+import boto3
 import pytest
+from moto import mock_dynamodb
 from src.mongo_recycler.models.decision import Decision, done, step_down_and_recycle_primary
 from src.mongo_recycler.models.instances import Instance
 from src.mongo_recycler.process.pre_step_checks import MongoReplicaSetMismatch
@@ -9,10 +12,7 @@ from src.mongo_recycler.process.step import (
     is_first_run,
     lambda_handler,
     step,
-    record_recycle_starting,
 )
-import boto3
-from moto import mock_dynamodb
 
 
 class LaunchException(Exception):

--- a/tests/unit/mongo_recycler/process/step_test.py
+++ b/tests/unit/mongo_recycler/process/step_test.py
@@ -1,10 +1,18 @@
 from unittest.mock import patch
-
+import unittest
 import pytest
 from src.mongo_recycler.models.decision import Decision, done, step_down_and_recycle_primary
 from src.mongo_recycler.models.instances import Instance
 from src.mongo_recycler.process.pre_step_checks import MongoReplicaSetMismatch
-from src.mongo_recycler.process.step import increment_counter, is_first_run, lambda_handler, step
+from src.mongo_recycler.process.step import (
+    increment_counter,
+    is_first_run,
+    lambda_handler,
+    step,
+    record_recycle_starting,
+)
+import boto3
+from moto import mock_dynamodb
 
 
 class LaunchException(Exception):
@@ -120,7 +128,8 @@ def test_lambda_handler_raises_exception_without_silencing_alerts(mock_requests)
 @patch("src.mongo_recycler.connectors.sensu.silence_sensu_alerts")
 @patch("src.mongo_recycler.process.step.step")
 @patch("src.mongo_recycler.process.step.json_logger_config")
-def test_lambda_handler_runs(mock_logger, mock_run, mock_alerts, mock_requests_post):
+@patch("boto3.resource")
+def test_lambda_handler_runs(mock_boto3, mock_logger, mock_run, mock_alerts, mock_requests_post):
     event = {
         "component": "test-component",
         "message_content": {
@@ -167,7 +176,10 @@ def test_lambda_handler_runs_successfully(mock_logger, mock_run, mock_alerts, mo
 @patch("src.mongo_recycler.connectors.sensu.silence_sensu_alerts")
 @patch("src.mongo_recycler.process.step.step")
 @patch("src.mongo_recycler.process.step.json_logger_config")
-def test_lambda_handler_returns_no_instance_recycled(mock_logger, mock_run, mock_alerts, mock_requests_post):
+@patch("boto3.resource")
+def test_lambda_handler_returns_no_instance_recycled(
+    mock_boto3, mock_logger, mock_run, mock_alerts, mock_requests_post
+):
     event = {
         "component": "test-component",
         "message_content": {


### PR DESCRIPTION
This change is to write to dynamodb to record when a mongo recycle is starting. This value will be checked by the mongo healthchecks to vary the alerts during a recycle. 
The auto-recycle lambda has been removed from the terraform pipeline so this changes will not be deployed anywhere except integration for manual testing at the moment