### PR TITLE
BAU Refactor get_component_name

### DIFF
--- a/src/autorecycle_invoke_stepfunctions/get_component_details.py
+++ b/src/autorecycle_invoke_stepfunctions/get_component_details.py
@@ -1,62 +1,61 @@
 #!/usr/bin/env python
 
 import logging
-from typing import Any, Tuple, Union
+from typing import Any, Optional
 
 logger = logging.getLogger(__name__)
 
 
-class NotRecyclable(Exception):
-    pass
+def get_component_name(event: dict[str, Any]) -> Optional[str]:
+    """
+    Extracts the component name from the event, if we determine the component should be recycled.
 
+    The component name is derived from the Auto Scaling Group (ASG) name.
+    If a component name was not found, None is returned.
 
-class EventDetailNotFound(Exception):
-    pass
+    This actually only returns the component name if the ASG tags were updated,
+    or the launchconfig/template was updated.
+    Any other ASG update event will not trigger a recycle.
+    """
 
+    component_name: str
 
-class ComponentNameNotSet(Exception):
-    pass
+    if "detail" not in event:
+        logger.info("No detail in event")
+        return None
 
+    if "requestParameters" not in event["detail"]:
+        logger.info("No requestParameters in event")
+        return None
 
-class RequestParametersNotFound(Exception):
-    pass
+    if event["detail"].get("eventName") in ["CreateOrUpdateTags", "DeleteTags"]:
+        if "tags" not in event["detail"]["requestParameters"]:
+            logger.info("No tags in event")
+            return None
 
+        component_name = event["detail"]["requestParameters"]["tags"][0]["resourceId"].split("-asg-")[0]
+        if not component_name:
+            logger.info("No component name in event")
+            return None
 
-def get_component_name(event: Any) -> Any:
-    try:
-        if event["detail"]:
-            if "requestParameters" in event["detail"]:
-                if event["detail"]["eventName"] == "CreateOrUpdateTags" or event["detail"]["eventName"] == "DeleteTags":
-                    if "tags" in event["detail"]["requestParameters"]:
-                        component_name = event["detail"]["requestParameters"]["tags"][0]["resourceId"].split("-asg-")[0]
-                        if component_name:
-                            logger.info("Component name was set to: {}".format(component_name))
-                            return component_name
-                        else:
-                            raise ComponentNameNotSet
-                else:
-                    component_name = event["detail"]["requestParameters"]["autoScalingGroupName"].split("-asg-")[0]
-                    if component_name:
-                        logger.info("Component name was set to: {}".format(component_name))
-                        if "launchConfigurationName" in event["detail"]["requestParameters"]:
-                            logger.info("This component: {} is using a launchConfiguration".format(component_name))
-                        elif "launchTemplate" in event["detail"]["requestParameters"]:
-                            logger.info("This component: {} is using a launchTemplate".format(component_name))
-                        else:
-                            logger.info(
-                                "The ASG was updated, but did not change the launchConfiguration or launchTemplate"
-                            )
-                            raise SystemExit
-                        return component_name
-                    else:
-                        raise ComponentNameNotSet
-            else:
-                raise RequestParametersNotFound
-        else:
-            raise EventDetailNotFound
-    except Exception as e:
-        logger.info("The event detail was not found when attempting to extract the component's name")
-        raise e
+        logger.info(f"Component name was set to: {component_name}")
+        return component_name
+
+    component_name = event["detail"]["requestParameters"]["autoScalingGroupName"].split("-asg-")[0]
+    if not component_name:
+        logger.info("No component name in event")
+        return None
+
+    logger.info(f"Component name was set to: {component_name}")
+
+    if (
+        "launchConfigurationName" not in event["detail"]["requestParameters"]
+        and "launchTemplate" not in event["detail"]["requestParameters"]
+    ):
+        logger.info("The launchConfiguration/launchTemplate is unchanged. Skipping recycling")
+        return None
+
+    return component_name
 
 
 def assert_recyclable(asg_tags: Any, component: Any, environment: Any) -> bool:

--- a/src/autorecycle_invoke_stepfunctions/get_component_details.py
+++ b/src/autorecycle_invoke_stepfunctions/get_component_details.py
@@ -20,11 +20,11 @@ def get_component_name(event: dict[str, Any]) -> Optional[str]:
 
     component_name: str
 
-    if "detail" not in event:
+    if "detail" not in event or not isinstance(event["detail"], dict):
         logger.info("No detail in event")
         return None
 
-    if "requestParameters" not in event["detail"]:
+    if "requestParameters" not in event["detail"] or not isinstance(event["detail"]["requestParameters"], dict):
         logger.info("No requestParameters in event")
         return None
 

--- a/src/autorecycle_invoke_stepfunctions/handler.py
+++ b/src/autorecycle_invoke_stepfunctions/handler.py
@@ -23,6 +23,7 @@ payload_to_asg_tag_map: dict[str, str] = dict(
 
 def lambda_handler(event: Any, context: Any) -> None:
     json_logger_config(event, context)
+    logger.info(event)
 
     component: Any = get_component_name(event)
     if component is None:

--- a/tests/unit/autorecycle_invoke_stepfunctions/test_get_component_details.py
+++ b/tests/unit/autorecycle_invoke_stepfunctions/test_get_component_details.py
@@ -44,27 +44,25 @@ class GetComponentDetails(unittest.TestCase):
 
         self.assertEqual("test-protected-mdtp", get_component_name(test_event_lt))
 
-    def test_exception_is_raised_with_no_event_detail(self):
+    def test_with_no_event_detail(self):
         """
-        When there is no event detail we should raise an exception
+        When there is no event detail we should return None
         """
         with open("tests/test_data/autorecycle_invoke_stepfunctions/test-event-launch-template.json", "rb") as f:
             test_event_lt = json.load(f)
 
         test_event_lt.pop("detail", None)
-        with self.assertRaises(KeyError):
-            get_component_name(test_event_lt)
+        assert get_component_name(test_event_lt) is None
 
     @patch.dict(os.environ, {"ACCOUNT_ID": "1234567890", "SLACK_CHANNEL": "event-test-recycle"})
-    def test_system_exit_is_raised_with_no_update(self):
+    def test_with_no_update(self):
         """
         When launchConfiguration or launchTemplate update not present UpdateAutoScalingGroup event
         """
         with open("tests/test_data/autorecycle_invoke_stepfunctions/test-event-no-update-present.json", "rb") as f:
             test_event_lt = json.load(f)
 
-        with self.assertRaises(SystemExit):
-            get_component_name(test_event_lt)
+        assert get_component_name(test_event_lt) is None
 
     def test_assert_recyclable_logs_message_when_component_is_recyclable(self):
         with self.assertLogs("src.autorecycle_invoke_stepfunctions.get_component_details", level="INFO") as logger:


### PR DESCRIPTION
This was written strangely, with deeply nested conditionals that throw exceptions that are immediately caught. There was also a SystemExit thrown in there that caused the runtime to error.

This has been deployed to integration and tested by triggering recycling from an updated launch template and also from changed ASG tags