### PR TITLE
INFRA-8543 Add test for payload used by instance retirement recycler

### DIFF
--- a/tests/test_data/autorecycle_invoke_stepfunctions/test-event-instance-retirement-recycler.json
+++ b/tests/test_data/autorecycle_invoke_stepfunctions/test-event-instance-retirement-recycler.json
@@ -1,0 +1,8 @@
+{
+   "detail": {
+      "requestParameters": {
+          "autoScalingGroupName": "test-protected-mdtp-asg-20191014094141784800000005",
+          "launchTemplate": "blah"
+      }
+   }
+}

--- a/tests/unit/autorecycle_invoke_stepfunctions/test_get_component_details.py
+++ b/tests/unit/autorecycle_invoke_stepfunctions/test_get_component_details.py
@@ -26,6 +26,17 @@ class GetComponentDetails(unittest.TestCase):
 
         self.assertEqual("test-protected-mdtp", get_component_name(test_event_lt))
 
+    def test_get_component_name_with_payload_from_instance_retirement_recycler(self):
+        """
+        With a payload submitted by the instance-retirement-recycler
+        """
+        with open(
+            "tests/test_data/autorecycle_invoke_stepfunctions/test-event-instance-retirement-recycler.json", "rb"
+        ) as f:
+            test_event_lt = json.load(f)
+
+        self.assertEqual("test-protected-mdtp", get_component_name(test_event_lt))
+
     def test_get_component_name_from_CreateOrUpdate_tag(self):
         """
         With a component which is recyclable and triggered from CreateOrUpdateTag Event


### PR DESCRIPTION
As part of [INFRA-8543](https://jira.tools.tax.service.gov.uk/browse/INFRA-8543), add a unit test to prove we can cope with the payload used by the instance-retirement-recycler.