### PR TITLE
add vpc security group for endpoints

### DIFF
--- a/terraform/consul_lambdas.tf
+++ b/terraform/consul_lambdas.tf
@@ -19,6 +19,7 @@ module "GetConsulNodes_lambda" {
   timeout                                 = 300
   vpc_id                                  = var.autorecycle_mongo_lambda_vpc_id
   vpc_subnet_ids                          = var.autorecycle_mongo_lambda_subnet_ids
+  security_group_ids                      = data.terraform_remote_state.networks.outputs.mdtp_vpc_aws_endpoint_access_sg
 }
 
 resource "aws_lambda_function_event_invoke_config" "GetConsulNodes_lambda" {

--- a/terraform/consul_lambdas.tf
+++ b/terraform/consul_lambdas.tf
@@ -19,7 +19,7 @@ module "GetConsulNodes_lambda" {
   timeout                                 = 300
   vpc_id                                  = var.autorecycle_mongo_lambda_vpc_id
   vpc_subnet_ids                          = var.autorecycle_mongo_lambda_subnet_ids
-  security_group_ids                      = data.terraform_remote_state.networks.outputs.mdtp_vpc_aws_endpoint_access_sg
+  security_group_ids                      = [data.terraform_remote_state.networks.outputs.mdtp_vpc_aws_endpoint_access_sg]
 }
 
 resource "aws_lambda_function_event_invoke_config" "GetConsulNodes_lambda" {

--- a/terraform/consul_lambdas.tf
+++ b/terraform/consul_lambdas.tf
@@ -122,6 +122,7 @@ module "TerminateConsulInstance_lambda" {
   timeout                                 = 300
   vpc_id                                  = var.autorecycle_mongo_lambda_vpc_id
   vpc_subnet_ids                          = var.autorecycle_mongo_lambda_subnet_ids
+  security_group_ids                      = [data.terraform_remote_state.networks.outputs.mdtp_vpc_aws_endpoint_access_sg]
 }
 
 resource "aws_lambda_function_event_invoke_config" "TerminateConsulInstance_lambda" {

--- a/terraform/local.tf
+++ b/terraform/local.tf
@@ -12,3 +12,13 @@ data "aws_region" "current" {}
 data "aws_sns_topic" "pagerduty_connector_noncritical" {
   name = "pagerduty_infrastructure_noncritical-${var.environment}"
 }
+
+data "terraform_remote_state" "networks" {
+  backend = "s3"
+
+  config = {
+    bucket = "tfstate-${var.environment}-${md5(data.aws_caller_identity.current.account_id)}"
+    region = data.aws_region.current.name
+    key    = "networks.tfstate"
+  }
+}


### PR DESCRIPTION
This change is to utilise the generic vpc endpoint security group rule instead of defining the individual vpc endpoint. This was a comment raised during inflight demo's