### PR TITLE
ls-18072025. Pass the VPC Endpoint SG in as a variable

### DIFF
--- a/terraform/consul_lambdas.tf
+++ b/terraform/consul_lambdas.tf
@@ -19,7 +19,7 @@ module "GetConsulNodes_lambda" {
   timeout                                 = 300
   vpc_id                                  = var.autorecycle_mongo_lambda_vpc_id
   vpc_subnet_ids                          = var.autorecycle_mongo_lambda_subnet_ids
-  security_group_ids                      = [data.terraform_remote_state.networks.outputs.mdtp_vpc_aws_endpoint_access_sg]
+  security_group_ids                      = var.vpc_endpoint_sg
 }
 
 resource "aws_lambda_function_event_invoke_config" "GetConsulNodes_lambda" {
@@ -122,7 +122,7 @@ module "TerminateConsulInstance_lambda" {
   timeout                                 = 300
   vpc_id                                  = var.autorecycle_mongo_lambda_vpc_id
   vpc_subnet_ids                          = var.autorecycle_mongo_lambda_subnet_ids
-  security_group_ids                      = [data.terraform_remote_state.networks.outputs.mdtp_vpc_aws_endpoint_access_sg]
+  security_group_ids                      = var.vpc_endpoint_sg
 }
 
 resource "aws_lambda_function_event_invoke_config" "TerminateConsulInstance_lambda" {

--- a/terraform/local.tf
+++ b/terraform/local.tf
@@ -12,13 +12,3 @@ data "aws_region" "current" {}
 data "aws_sns_topic" "pagerduty_connector_noncritical" {
   name = "pagerduty_infrastructure_noncritical-${var.environment}"
 }
-
-data "terraform_remote_state" "networks" {
-  backend = "s3"
-
-  config = {
-    bucket = "tfstate-${var.environment}-${md5(data.aws_caller_identity.current.account_id)}"
-    region = data.aws_region.current.name
-    key    = "networks.tfstate"
-  }
-}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -79,3 +79,8 @@ variable "start_instance_refresh_lambda_name" {
   type        = string
   default     = ""
 }
+
+variable "vpc_endpoint_sg" {
+  description = "VPC Endpoint Security Group"
+  type        = list(string)
+}


### PR DESCRIPTION
This is becuase the management state file doesn't conform to 
bucket = "tfstate-${var.environment}-${md5(data.aws_caller_identity.current.account_id)}"
so instead of the module querying state to determine the SG id it has to be provided by consumers of the module