### PR TITLE
INFRA-8707. Make consul recycle step function fail 

### DIFF
--- a/terraform/consul_recycle_state_machine.tf
+++ b/terraform/consul_recycle_state_machine.tf
@@ -179,7 +179,12 @@ resource "aws_sfn_state_machine" "recycle_consul_agents" {
         },
         "username": "AutoRecycling"
       },
-      "End": true
+      "Next": "FailState"
+    },
+    "FailState": {
+      "Type": "Fail",
+      "Error": "AutoRecyclingFailed",
+      "Cause": "Error encountered during Consul Recycle"
     }
   }
 }


### PR DESCRIPTION
This change will make the consul step function fail if any of the subordinate tasks produce an alert. 
Previously the step function didn't fail because it was the subordinate task that handled the error and alerting. This is a bit confusing so I now want to make the whole thing fail too