### PR TITLE
INFRA-8710 Use TLS for talking to Consul

### DIFF
--- a/src/check_consul_health/main.py
+++ b/src/check_consul_health/main.py
@@ -1,7 +1,55 @@
 import json
+import logging
 import os
+import ssl
+import tempfile
 import urllib.request
-from typing import Any
+from typing import Any, Optional
+
+import boto3
+
+logger = logging.getLogger(__name__)
+
+class CaCertificate:
+    """
+    Manage CA certificate retrieval and caching.
+    """
+
+    def __init__(self, cert_parameter_arn: Optional[str] = None):
+        self._cert_path: Optional[str] = None
+        self.cert_parameter_arn = cert_parameter_arn
+
+    @property
+    def cert_path(self) -> Optional[str]:
+        """Get the certificate file path, retrieving it if necessary."""
+        if self._cert_path is None and self.cert_parameter_arn:
+            self._retrieve_cert()
+        return self._cert_path
+
+    def _retrieve_cert(self) -> None:
+        """Retrieve certificate from Parameter Store and write to temp file."""
+        if not self.cert_parameter_arn:
+            logger.info('No TLS certificate ARN configured')
+            return
+
+        try:
+            logger.info(f'Retrieving CA certificate from parameter: {self.cert_parameter_arn}')
+            ssm = boto3.client('ssm', region_name='eu-west-2')
+            response = ssm.get_parameter(Name=self.cert_parameter_arn, WithDecryption=True)
+            cert_content = response['Parameter']['Value']
+
+            with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.pem') as f:
+                f.write(cert_content)
+                self._cert_path = f.name
+
+            logger.info(f'Successfully retrieved CA certificate and wrote to {self._cert_path}')
+
+        except Exception:
+            logger.exception('Failed to retrieve CA certificate')
+            raise
+
+
+ca_certificate = CaCertificate(os.environ.get('CONSUL_TLS_CERT_PARAMETER_ARN'))
 
 
 # Normally we connect to consul-{environment}.{environment}.mdtp but we also support
@@ -13,7 +61,15 @@ def get_consul_host(event: Any) -> str:
         print(event)
 
     cluster = event.get("cluster", environment)
-    return f"http://consul-{cluster}.{environment}.mdtp:8500"
+    return f"https://consul-{cluster}.{environment}.mdtp:8501"
+
+
+def get_ssl_context() -> ssl.SSLContext:
+    """Create SSL context with CA certificate if available."""
+    ctx = ssl.create_default_context()
+    if ca_certificate.cert_path:
+        ctx.load_verify_locations(ca_certificate.cert_path)
+    return ctx
 
 
 def lambda_handler(event: Any, context: Any) -> Any:
@@ -21,15 +77,17 @@ def lambda_handler(event: Any, context: Any) -> Any:
 
     expected_peers = event.get("expectedPeers", 3)  # Default to 3 if not provided
 
+    ssl_context = get_ssl_context()
+
     try:
         # Check for leader
-        with urllib.request.urlopen(f"{consul_host}/v1/status/leader") as res:  # nosec
+        with urllib.request.urlopen(f"{consul_host}/v1/status/leader", context=ssl_context) as res:  # nosec
             leader = res.read().decode().strip().strip('"')
             if not leader:
                 raise Exception("No leader found")
 
         # Check number of nodes in the cluster is as expected.
-        with urllib.request.urlopen(f"{consul_host}/v1/status/peers") as res:  # nosec
+        with urllib.request.urlopen(f"{consul_host}/v1/status/peers", context=ssl_context) as res:  # nosec
             peers = json.loads(res.read().decode())
             if len(peers) != expected_peers:
                 raise Exception(f"{len(peers)} peers found, expected {expected_peers}")

--- a/src/check_consul_health/main.py
+++ b/src/check_consul_health/main.py
@@ -10,6 +10,7 @@ import boto3
 
 logger = logging.getLogger(__name__)
 
+
 class CaCertificate:
     """
     Manage CA certificate retrieval and caching.
@@ -29,27 +30,27 @@ class CaCertificate:
     def _retrieve_cert(self) -> None:
         """Retrieve certificate from Parameter Store and write to temp file."""
         if not self.cert_parameter_arn:
-            logger.info('No TLS certificate ARN configured')
+            logger.info("No TLS certificate ARN configured")
             return
 
         try:
-            logger.info(f'Retrieving CA certificate from parameter: {self.cert_parameter_arn}')
-            ssm = boto3.client('ssm', region_name='eu-west-2')
+            logger.info(f"Retrieving CA certificate from parameter: {self.cert_parameter_arn}")
+            ssm = boto3.client("ssm", region_name="eu-west-2")
             response = ssm.get_parameter(Name=self.cert_parameter_arn, WithDecryption=True)
-            cert_content = response['Parameter']['Value']
+            cert_content = response["Parameter"]["Value"]
 
-            with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.pem') as f:
+            with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".pem") as f:
                 f.write(cert_content)
                 self._cert_path = f.name
 
-            logger.info(f'Successfully retrieved CA certificate and wrote to {self._cert_path}')
+            logger.info(f"Successfully retrieved CA certificate and wrote to {self._cert_path}")
 
         except Exception:
-            logger.exception('Failed to retrieve CA certificate')
+            logger.exception("Failed to retrieve CA certificate")
             raise
 
 
-ca_certificate = CaCertificate(os.environ.get('CONSUL_TLS_CERT_PARAMETER_ARN'))
+ca_certificate = CaCertificate(os.environ.get("CONSUL_TLS_CERT_PARAMETER_ARN"))
 
 
 # Normally we connect to consul-{environment}.{environment}.mdtp but we also support

--- a/src/get_consul_nodes/main.py
+++ b/src/get_consul_nodes/main.py
@@ -10,6 +10,7 @@ import boto3
 
 logger = logging.getLogger(__name__)
 
+
 class CaCertificate:
     """
     Manage CA certificate retrieval and caching.
@@ -29,27 +30,27 @@ class CaCertificate:
     def _retrieve_cert(self) -> None:
         """Retrieve certificate from Parameter Store and write to temp file."""
         if not self.cert_parameter_arn:
-            logger.info('No TLS certificate ARN configured')
+            logger.info("No TLS certificate ARN configured")
             return
 
         try:
-            logger.info(f'Retrieving CA certificate from parameter: {self.cert_parameter_arn}')
-            ssm = boto3.client('ssm', region_name='eu-west-2')
+            logger.info(f"Retrieving CA certificate from parameter: {self.cert_parameter_arn}")
+            ssm = boto3.client("ssm", region_name="eu-west-2")
             response = ssm.get_parameter(Name=self.cert_parameter_arn, WithDecryption=True)
-            cert_content = response['Parameter']['Value']
+            cert_content = response["Parameter"]["Value"]
 
-            with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.pem') as f:
+            with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".pem") as f:
                 f.write(cert_content)
                 self._cert_path = f.name
 
-            logger.info(f'Successfully retrieved CA certificate and wrote to {self._cert_path}')
+            logger.info(f"Successfully retrieved CA certificate and wrote to {self._cert_path}")
 
         except Exception:
-            logger.exception('Failed to retrieve CA certificate')
+            logger.exception("Failed to retrieve CA certificate")
             raise
 
 
-ca_certificate = CaCertificate(os.environ.get('CONSUL_TLS_CERT_PARAMETER_ARN'))
+ca_certificate = CaCertificate(os.environ.get("CONSUL_TLS_CERT_PARAMETER_ARN"))
 
 
 # Normally we connect to consul-{environment}.{environment}.mdtp but we also support

--- a/src/get_consul_nodes/main.py
+++ b/src/get_consul_nodes/main.py
@@ -1,9 +1,55 @@
 import json
+import logging
 import os
+import ssl
+import tempfile
 import urllib.request
-from typing import Any
+from typing import Any, Optional
 
 import boto3
+
+logger = logging.getLogger(__name__)
+
+class CaCertificate:
+    """
+    Manage CA certificate retrieval and caching.
+    """
+
+    def __init__(self, cert_parameter_arn: Optional[str] = None):
+        self._cert_path: Optional[str] = None
+        self.cert_parameter_arn = cert_parameter_arn
+
+    @property
+    def cert_path(self) -> Optional[str]:
+        """Get the certificate file path, retrieving it if necessary."""
+        if self._cert_path is None and self.cert_parameter_arn:
+            self._retrieve_cert()
+        return self._cert_path
+
+    def _retrieve_cert(self) -> None:
+        """Retrieve certificate from Parameter Store and write to temp file."""
+        if not self.cert_parameter_arn:
+            logger.info('No TLS certificate ARN configured')
+            return
+
+        try:
+            logger.info(f'Retrieving CA certificate from parameter: {self.cert_parameter_arn}')
+            ssm = boto3.client('ssm', region_name='eu-west-2')
+            response = ssm.get_parameter(Name=self.cert_parameter_arn, WithDecryption=True)
+            cert_content = response['Parameter']['Value']
+
+            with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.pem') as f:
+                f.write(cert_content)
+                self._cert_path = f.name
+
+            logger.info(f'Successfully retrieved CA certificate and wrote to {self._cert_path}')
+
+        except Exception:
+            logger.exception('Failed to retrieve CA certificate')
+            raise
+
+
+ca_certificate = CaCertificate(os.environ.get('CONSUL_TLS_CERT_PARAMETER_ARN'))
 
 
 # Normally we connect to consul-{environment}.{environment}.mdtp but we also support
@@ -15,7 +61,15 @@ def get_consul_host(event: Any) -> str:
         print(event)
 
     cluster = event.get("cluster", environment)
-    return f"http://consul-{cluster}.{environment}.mdtp:8500"
+    return f"https://consul-{cluster}.{environment}.mdtp:8501"
+
+
+def get_ssl_context() -> ssl.SSLContext:
+    """Create SSL context with CA certificate if available."""
+    ctx = ssl.create_default_context()
+    if ca_certificate.cert_path:
+        ctx.load_verify_locations(ca_certificate.cert_path)
+    return ctx
 
 
 def lambda_handler(event: Any, context: Any) -> Any:
@@ -23,13 +77,15 @@ def lambda_handler(event: Any, context: Any) -> Any:
 
     ec2 = boto3.client("ec2")
 
+    ssl_context = get_ssl_context()
+
     try:
         # Get Consul leader IP
-        with urllib.request.urlopen(f"{consul_host}/v1/status/leader") as res:  # nosec
+        with urllib.request.urlopen(f"{consul_host}/v1/status/leader", context=ssl_context) as res:  # nosec
             leader = res.read().decode().strip().strip('"').split(":")[0]
 
         # Get all members of the control plane
-        with urllib.request.urlopen(f"{consul_host}/v1/agent/members") as res:  # nosec
+        with urllib.request.urlopen(f"{consul_host}/v1/agent/members", context=ssl_context) as res:  # nosec
             members = json.loads(res.read().decode())
 
         # Sort all the members, putting the leader last in the list

--- a/terraform/consul_lambdas.tf
+++ b/terraform/consul_lambdas.tf
@@ -7,6 +7,7 @@ module "GetConsulNodes_lambda" {
   environment                  = var.environment
   environment_variables = {
     environment = var.environment
+    CONSUL_TLS_CERT_PARAMETER_ARN = var.consul_ca_cert_arn
   }
   enable_error_alarm                      = true
   error_alarm_runbook                     = local.lambda_error_runbook_url
@@ -37,6 +38,26 @@ data "aws_iam_policy_document" "aws_autorecycle_GetConsulNodes_lambda_policy" {
     actions   = ["sqs:SendMessage"]
     resources = ["arn:aws:sqs:eu-west-2:${data.aws_caller_identity.current.account_id}:recycle-*"]
   }
+
+  statement {
+    effect    = "Allow"
+    actions   = ["ssm:GetParameter"]
+    resources = [var.consul_ca_cert_arn]
+  }
+
+  # Allow decryption of parameters encrypted with default SSM key
+  statement {
+    effect = "Allow"
+    actions = [
+      "kms:Decrypt"
+    ]
+    resources = ["arn:aws:kms:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:alias/aws/ssm"]
+    condition {
+      test     = "StringEquals"
+      variable = "kms:ViaService"
+      values   = ["ssm.eu-west-2.amazonaws.com"]
+    }
+  }
 }
 
 resource "aws_iam_role_policy" "aws_autorecycle_GetConsulNodes_lambda" {
@@ -56,6 +77,7 @@ module "CheckClusterHealth_lambda" {
   environment                  = var.environment
   environment_variables = {
     environment = var.environment
+    CONSUL_TLS_CERT_PARAMETER_ARN = var.consul_ca_cert_arn
   }
   enable_error_alarm                      = true
   error_alarm_runbook                     = local.lambda_error_runbook_url
@@ -84,6 +106,26 @@ data "aws_iam_policy_document" "aws_autorecycle_CheckClusterHealth_lambda_policy
     effect    = "Allow"
     actions   = ["sqs:SendMessage"]
     resources = ["arn:aws:sqs:eu-west-2:${data.aws_caller_identity.current.account_id}:recycle-*"]
+  }
+
+  statement {
+    effect    = "Allow"
+    actions   = ["ssm:GetParameter"]
+    resources = [var.consul_ca_cert_arn]
+  }
+
+  # Allow decryption of parameters encrypted with default SSM key
+  statement {
+    effect = "Allow"
+    actions = [
+      "kms:Decrypt"
+    ]
+    resources = ["arn:aws:kms:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:alias/aws/ssm"]
+    condition {
+      test     = "StringEquals"
+      variable = "kms:ViaService"
+      values   = ["ssm.eu-west-2.amazonaws.com"]
+    }
   }
 }
 

--- a/terraform/consul_lambdas.tf
+++ b/terraform/consul_lambdas.tf
@@ -6,7 +6,7 @@ module "GetConsulNodes_lambda" {
   account_engineering_boundary = var.account_engineering_boundary
   environment                  = var.environment
   environment_variables = {
-    environment = var.environment
+    environment                   = var.environment
     CONSUL_TLS_CERT_PARAMETER_ARN = var.consul_ca_cert_arn
   }
   enable_error_alarm                      = true
@@ -76,7 +76,7 @@ module "CheckClusterHealth_lambda" {
   account_engineering_boundary = var.account_engineering_boundary
   environment                  = var.environment
   environment_variables = {
-    environment = var.environment
+    environment                   = var.environment
     CONSUL_TLS_CERT_PARAMETER_ARN = var.consul_ca_cert_arn
   }
   enable_error_alarm                      = true

--- a/terraform/consul_recycle_state_machine.tf
+++ b/terraform/consul_recycle_state_machine.tf
@@ -77,9 +77,9 @@ resource "aws_sfn_state_machine" "recycle_consul_agents" {
                       "Parameters": {
                         "commands": [
                           "echo 'Checking Consul leader status...'",
-                          "curl -s https://localhost:8501/v1/status/leader || echo 'Consul not responding, not running or leaderless'",
+                          "curl --cacert /etc/consul/tls/consul-agent-ca.pem -s https://localhost:8501/v1/status/leader || echo 'Consul not responding, not running or leaderless'",
                           "echo 'Attempting graceful leave...'",
-                          "curl -X PUT https://localhost:8501/v1/agent/leave || echo 'Leave command failed'"
+                          "curl --cacert /etc/consul/tls/consul-agent-ca.pem -X PUT https://localhost:8501/v1/agent/leave || echo 'Leave command failed'"
                         ]
                       }
                     },

--- a/terraform/consul_recycle_state_machine.tf
+++ b/terraform/consul_recycle_state_machine.tf
@@ -77,9 +77,9 @@ resource "aws_sfn_state_machine" "recycle_consul_agents" {
                       "Parameters": {
                         "commands": [
                           "echo 'Checking Consul leader status...'",
-                          "curl -s http://localhost:8500/v1/status/leader || echo 'Consul not responding, not running or leaderless'",
+                          "curl -s https://localhost:8501/v1/status/leader || echo 'Consul not responding, not running or leaderless'",
                           "echo 'Attempting graceful leave...'",
-                          "curl -X PUT http://localhost:8500/v1/agent/leave || echo 'Leave command failed'"
+                          "curl -X PUT https://localhost:8501/v1/agent/leave || echo 'Leave command failed'"
                         ]
                       }
                     },

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -84,3 +84,9 @@ variable "vpc_endpoint_sg" {
   description = "VPC Endpoint Security Group"
   type        = list(string)
 }
+
+variable "consul_ca_cert_arn" {
+  description = "The ARN of the SSM parameter containing the Consul TLS CA certificate"
+  type        = string
+  default     = ""
+}

--- a/tests/unit/check_consul_health/test_check_consul_health.py
+++ b/tests/unit/check_consul_health/test_check_consul_health.py
@@ -66,7 +66,7 @@ class TestLambdaHandler(unittest.TestCase):
     def test_consul_returns_500(self, mock_urlopen):
         # Simulate a 500 Internal Server Error from Consul
         mock_urlopen.side_effect = urllib.error.HTTPError(
-            url="http://consul-test.test.mdtp:8500/v1/status/leader",
+            url="https://consul-test.test.mdtp:8501/v1/status/leader",
             code=500,
             msg="Internal Server Error",
             hdrs=None,
@@ -81,11 +81,11 @@ class TestLambdaHandler(unittest.TestCase):
 
     @patch.dict(os.environ, {"environment": "integration"})
     def test_get_consul_host_defaults_to_environment(self):
-        self.assertEqual(get_consul_host({}), "http://consul-integration.integration.mdtp:8500")
+        self.assertEqual(get_consul_host({}), "https://consul-integration.integration.mdtp:8501")
 
     @patch.dict(os.environ, {"environment": "integration"})
     def test_get_consul_host_includes_cluster(self):
-        self.assertEqual(get_consul_host({"cluster": "dev-1"}), "http://consul-dev-1.integration.mdtp:8500")
+        self.assertEqual(get_consul_host({"cluster": "dev-1"}), "https://consul-dev-1.integration.mdtp:8501")
 
 
 if __name__ == "__main__":

--- a/tests/unit/get_consul_nodes/test_get_consul_nodes.py
+++ b/tests/unit/get_consul_nodes/test_get_consul_nodes.py
@@ -63,7 +63,7 @@ class TestLambdaHandler(unittest.TestCase):
     def test_leader_request_fails(self, mock_urlopen, mock_boto_client):
         # Simulate a 500 error from /v1/status/leader
         mock_urlopen.side_effect = urllib.error.HTTPError(
-            url="http://consul-test.test.mdtp:8500/v1/status/leader",
+            url="https://consul-test.test.mdtp:8501/v1/status/leader",
             code=500,
             msg="Internal Server Error",
             hdrs=None,
@@ -78,11 +78,11 @@ class TestLambdaHandler(unittest.TestCase):
 
     @patch.dict(os.environ, {"environment": "integration"})
     def test_get_consul_host_defaults_to_environment(self):
-        self.assertEqual(get_consul_host({}), "http://consul-integration.integration.mdtp:8500")
+        self.assertEqual(get_consul_host({}), "https://consul-integration.integration.mdtp:8501")
 
     @patch.dict(os.environ, {"environment": "integration"})
     def test_get_consul_host_includes_cluster(self):
-        self.assertEqual(get_consul_host({"cluster": "dev-1"}), "http://consul-dev-1.integration.mdtp:8500")
+        self.assertEqual(get_consul_host({"cluster": "dev-1"}), "https://consul-dev-1.integration.mdtp:8501")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This makes the consul recycler use TLS for requests to consul.

This has been tested by applying to integration and triggering a recycle of the integration cluster - it worked.