### PR TITLE
INFRA-8710 Add missing security group

### DIFF
--- a/terraform/consul_lambdas.tf
+++ b/terraform/consul_lambdas.tf
@@ -91,6 +91,7 @@ module "CheckClusterHealth_lambda" {
   timeout                                 = 300
   vpc_id                                  = var.autorecycle_mongo_lambda_vpc_id
   vpc_subnet_ids                          = var.autorecycle_mongo_lambda_subnet_ids
+  security_group_ids                      = var.vpc_endpoint_sg
 }
 
 resource "aws_lambda_function_event_invoke_config" "CheckClusterHealth_lambda" {


### PR DESCRIPTION
Add the aws vpc access security group to one of the lambdas. The other lambdas already have it.
This allows the lambda to fetch the CA cert from SSM