### PR TITLE
BAU: Uncolour recycle initiation messages

### DIFF
--- a/terraform/state_machine.tf
+++ b/terraform/state_machine.tf
@@ -205,7 +205,6 @@ resource "aws_sfn_state_machine" "auto_recycle" {
           "${var.slack_channel}"
         ],
         "message_content": {
-          "color": "good",
           "text": "Auto-recycling was successfully initiated",
           "fields": [
             {
@@ -300,7 +299,6 @@ resource "aws_sfn_state_machine" "auto_recycle" {
           "${var.slack_channel}"
         ],
         "message_content": {
-          "color": "good",
           "text": "Instance refresh was successfully initiated",
           "fields": [
             {


### PR DESCRIPTION
For ECS service deployment messages we have deployment initiation Slack messages uncoloured and deployment completion messages coloured green. This makes it easier to find the start and end of a deployment in the Slack channel.
For the autorecycle state machine both initiation and completion messages are coloured green.

Change recycle initiation messages to be uncoloured to differentiate them from recycle completion messages.