### PR TITLE
Fix for the checkclusterhealth lambda INFRA-8891

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -40,7 +40,7 @@ services:
       GIT_SSH_COMMAND: 'ssh -i /root/.ssh/ssh_key -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new'
     volumes:
       - ./:/work
-      - ${SSH_KEY_PATH}:/root/.ssh/ssh_key:ro
+      - ${SSH_KEY_PATH:-/dev/null}:/root/.ssh/ssh_key:ro
       - ${SSH_AUTH_SOCK}:/tmp/ssh-agent.sock
 
   python-tools:

--- a/src/check_consul_health/main.py
+++ b/src/check_consul_health/main.py
@@ -76,7 +76,7 @@ def get_ssl_context() -> ssl.SSLContext:
 def lambda_handler(event: Any, context: Any) -> Any:
     consul_host = get_consul_host(event)
 
-    expected_peers = event.get("expectedPeers", 3)  # Default to 3 if not provided
+    expected_peers = event.get("expectedPeers", 5)
 
     ssl_context = get_ssl_context()
 

--- a/terraform/consul_recycle_state_machine.tf
+++ b/terraform/consul_recycle_state_machine.tf
@@ -97,7 +97,7 @@ resource "aws_sfn_state_machine" "recycle_consul_agents" {
                     "ResultPath": "$.healthCheck",
                     "Parameters": {
                       "cluster.$": "$$.Execution.Input.cluster",
-                      "expectedPeers": 2
+                      "expectedPeers": 4
                     },
                     "Retry": [{
                       "ErrorEquals": ["States.ALL"],

--- a/terraform/consul_recycle_state_machine.tf
+++ b/terraform/consul_recycle_state_machine.tf
@@ -31,7 +31,7 @@ resource "aws_sfn_state_machine" "recycle_consul_agents" {
             },
             "CheckClusterHealthInitial": {
               "Type": "Task",
-              "Comment": "Check that consul is healthy before we start. 1 leader and 2 followers totalling 3 members",
+              "Comment": "Check that consul is healthy before we start. 1 leader and 4 followers totalling 5 members",
               "Resource": "${local.check_cluster_health_lambda_arn}",
               "Parameters": {
                 "cluster.$": "$$.Execution.Input.cluster"

--- a/terraform/consul_recycle_state_machine.tf
+++ b/terraform/consul_recycle_state_machine.tf
@@ -97,7 +97,7 @@ resource "aws_sfn_state_machine" "recycle_consul_agents" {
                     "ResultPath": "$.healthCheck",
                     "Parameters": {
                       "cluster.$": "$$.Execution.Input.cluster",
-                      "expectedPeers": 4
+                      "expectedPeers": 5
                     },
                     "Retry": [{
                       "ErrorEquals": ["States.ALL"],

--- a/tests/unit/check_consul_health/test_check_consul_health.py
+++ b/tests/unit/check_consul_health/test_check_consul_health.py
@@ -19,7 +19,7 @@ class TestLambdaHandler(unittest.TestCase):
 
         # Mock response for /v1/status/peers
         mock_peers_response = MagicMock()
-        mock_peers_response.read.return_value = json.dumps(["a", "b", "c"]).encode("utf-8")
+        mock_peers_response.read.return_value = json.dumps(["a", "b", "c", "a2", "b2"]).encode("utf-8")
         mock_peers_response.__enter__.return_value = mock_peers_response
 
         mock_urlopen.side_effect = [mock_leader_response, mock_peers_response]

--- a/tests/unit/check_consul_health/test_check_consul_health.py
+++ b/tests/unit/check_consul_health/test_check_consul_health.py
@@ -24,7 +24,7 @@ class TestLambdaHandler(unittest.TestCase):
 
         mock_urlopen.side_effect = [mock_leader_response, mock_peers_response]
 
-        event = {"expectedPeers": 3}
+        event = {"expectedPeers": 5}
         response = lambda_handler(event, None)
 
         self.assertEqual(response["statusCode"], 200)
@@ -57,7 +57,7 @@ class TestLambdaHandler(unittest.TestCase):
         mock_urlopen.side_effect = [mock_leader_response, mock_peers_response]
 
         with self.assertRaises(Exception) as context:
-            lambda_handler({"expectedPeers": 3}, None)
+            lambda_handler({"expectedPeers": 5}, None)
 
         self.assertIn("1 peers found", str(context.exception))
 


### PR DESCRIPTION
Fix for the checkclusterhealth lambda and configuring the peers from from 3 to 5

{
  "errorMessage": "Cluster health check failed: 5 peers found, expected 2",
  "errorType": "Exception",
  "requestId": "a448adf6-ab1e-4b94-9d3b-942c8c560a44",
  "stackTrace": [
    "  File \"/var/task/src/check_consul_health/main.py\", line 102, in lambda_handler\n    raise Exception(f\"Cluster health check failed: {e}\")\n"
  ]
}