### PR TITLE
Changed the number of peers to 4 for CheckClusterHealthPostLeave INFRA-8891

### DIFF
--- a/terraform/consul_recycle_state_machine.tf
+++ b/terraform/consul_recycle_state_machine.tf
@@ -97,7 +97,7 @@ resource "aws_sfn_state_machine" "recycle_consul_agents" {
                     "ResultPath": "$.healthCheck",
                     "Parameters": {
                       "cluster.$": "$$.Execution.Input.cluster",
-                      "expectedPeers": 5
+                      "expectedPeers": 4
                     },
                     "Retry": [{
                       "ErrorEquals": ["States.ALL"],


### PR DESCRIPTION
Changed the number of peers to 4 for CheckClusterHealthPostLeave

