### PR TITLE
INFRA-8942: Fix autorecycle Slack message handling to prevent missing message_content

### DIFF
--- a/src/autorecycle_scale_asg/handler.py
+++ b/src/autorecycle_scale_asg/handler.py
@@ -103,9 +103,13 @@ def scale_asg(event: Event) -> Event:
                     fields=message_content_fields,
                     text="Auto-recycling has successfully initiated",
                 )
-                output.recycle_success = False
             else:
-                output.recycle_success = False
+                output.message_content = Event.MessageContent(
+                    color="good",
+                    fields=message_content_fields,
+                    text="Auto-recycling is already in progress",
+                )
+            output.recycle_success = False
             return output
 
         logger.info("Autorecycling has successfully completed")


### PR DESCRIPTION

Ensure Event.MessageContent is always created with a valid text field when initiating a scaling action.

tested locally with temp file
python -m pytest tests/test_autorecycle_slack_error.py
check and reestablish error without change code and with change code 
